### PR TITLE
Adds cookie policy javascript

### DIFF
--- a/app/views/shared/_head.html.erb
+++ b/app/views/shared/_head.html.erb
@@ -1,3 +1,14 @@
+<% if Rails.application.config.respond_to?(:siteimprove_cookie_policy) && Rails.application.config.siteimprove_cookie_policy.try(:[], :url) %>
+    <script type="text/javascript">
+    /*<![CDATA[*/
+    (function() {
+        var sz = document.createElement('script'); sz.type = 'text/javascript'; sz.async = true;
+        sz.src = '<%= Rails.application.config.siteimprove_cookie_policy[:url] %>';
+        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(sz, s);
+    })();
+    /*]]>*/
+    </script>
+<% end %>
 <link href="<%= opensearch_catalog_path(:format => 'xml', :only_path => false) %>" title="<%= application_name%>" type="application/opensearchdescription+xml" rel="search"/>
 <% if Rails.application.config.respond_to?(:google) && Rails.application.config.google.try(:[], :maps_v3).try(:[], :api_key) %>
   <script src="https://maps.googleapis.com/maps/api/js?key=<%= Rails.application.config.google[:maps_v3][:api_key] %>"></script>


### PR DESCRIPTION
Adds some JavaScript that adds a cookie policy banner to pages.

The cookie policy banner is sourced from a configurable URL. In production this URL will have to be configured.
