### PR TITLE
Refine search

### DIFF
--- a/app/assets/javascripts/refine_search.js
+++ b/app/assets/javascripts/refine_search.js
@@ -1,0 +1,118 @@
+(function($) {
+  $(function() {
+    var refineSearchQueryElement = $('#refine_search_query');
+    if (!refineSearchQueryElement)
+      return;
+
+    var doRefinedSearchButton = $('#do_refined_search');
+    if (!doRefinedSearchButton)
+      return;
+
+    var showRefineSearchButton = $('#show_refine_search_query');
+    if (!showRefineSearchButton)
+      return;
+
+    var query = refineSearchQueryElement.data('query');
+
+    var refinedTitleInput = $('#refined_title_input');
+    var refinedJournalInput = $('#refined_journal_input');
+    var refinedVolumeInput = $('#refined_volume_input');
+    var refinedPagesInput = $('#refined_pages_input');
+    var refinedPublisherInput = $('#refined_publisher_input');
+    var refinedYearInput = $('#refined_year_input');
+    var refinedAuthorsInput = $('#refined_authors_input');
+
+    var parseQuery = function(query) {
+      var setRefinedTitle = function(newTitle) {
+        refinedTitleInput.val(newTitle);
+      };
+
+      var setRefinedJournalTitle = function(newJournalTitle) {
+        refinedJournalInput.val(newJournalTitle);
+      };
+
+      var setRefinedVolume = function(newVolume) {
+        refinedVolumeInput.val(newVolume);
+      };
+
+      var setRefinedPages = function(newPages) {
+        refinedPagesInput.val(newPages);
+      };
+
+      var setRefinedPublisher = function(newPublisher) {
+        refinedPublisherInput.val(newPublisher);
+      };
+
+      var setRefinedYear = function(newYear) {
+        refinedYearInput.val(newYear);
+      };
+
+      var setRefinedAuthors = function(newAuthors) {
+        refinedAuthorsInput.val(newAuthors);
+      };
+
+      var queryFreeCite = function() {
+        $.ajax(
+            "/refine_search/parse_search_query",
+            {
+              method: "GET",
+              data: { q: query },
+            }
+        ).then(
+          function(data, textStatus, jqXHR) {
+            setRefinedAuthors(data.authors);
+            setRefinedTitle(data.title);
+            setRefinedJournalTitle(data.journal_title);
+            setRefinedVolume(data.volume);
+            setRefinedPages(data.pages);
+            setRefinedPublisher(data.publisher);
+            setRefinedYear(data.year);
+            showRefineSearchButton.show();
+          },
+          function(jqXHR, textStatus, errorThrown) {
+            console.log("parse_search_query request failed.");
+          }
+        );
+      };
+
+      if (query !== null && query !== undefined && query !== "")
+        queryFreeCite();
+    };
+
+    parseQuery(query);
+
+    doRefinedSearchButton.click(function() {
+      var constructUrl = function() {
+        var baseUrl = "/en/catalog?q=";
+
+        var params = [];
+        if (refinedAuthorsInput.val())
+          params.push('authors:"' + refinedAuthorsInput.val() + '"');
+        if (refinedTitleInput.val())
+          params.push('title:"' + refinedTitleInput.val() + '"');
+        if (refinedJournalInput.val())
+          params.push('journal_title:"' + refinedJournalInput.val() + '"');
+        if (refinedVolumeInput.val())
+          params.push('volume:"' + refinedVolumeInput.val() + '"');
+        if (refinedPublisherInput.val())
+          params.push('publisher:"' + refinedPublisherInput.val() + '"');
+        if (refinedYearInput.val())
+          params.push('year:"' + refinedYearInput.val() + '"');
+        if (refinedPagesInput.val())
+          params.push('pages:"' + refinedPagesInput.val() + '"');
+
+        var result = baseUrl + encodeURI(params.join(" "));
+
+        return result;
+      };
+
+      $(this).attr("href", constructUrl());
+    });
+
+    showRefineSearchButton.click(function() {
+      showRefineSearchButton.hide();
+      refineSearchQueryElement.show();
+    });
+  });
+})(jQuery);
+

--- a/app/assets/stylesheets/refine_search.scss
+++ b/app/assets/stylesheets/refine_search.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the refine_search controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -239,6 +239,7 @@ class CatalogController < ApplicationController
       params.delete :from_resolver
     end
 
+    @query = URI.encode((params[:q] || ""))
     (@response, @document_list) = get_search_results(params, extra_search_params)
     @filters = params[:f] || []
 

--- a/app/controllers/refine_search_controller.rb
+++ b/app/controllers/refine_search_controller.rb
@@ -1,0 +1,55 @@
+require 'uri'
+
+class RefineSearchController < ApplicationController
+  def parse_search_query
+    query = URI.decode(params[:q] || "")
+
+    if query.nil? || query.empty?
+      render status: :unprocessable_entity, text: "paramter 'q' must not be empty."
+      return
+    end
+
+    if already_refined?(query)
+      render json: parse_refined_query_to_jsonable_structure(query)
+      return
+    end
+
+    freecite_response = FreeciteHelper::FreeciteRequest.new(query).call
+    render json: map_freecite_response_to_jsonable_toshokan_response(freecite_response)
+  end
+
+  private
+
+  def map_freecite_response_to_jsonable_toshokan_response(freecite_response)
+    {
+      "authors" => freecite_response.unabbreviated_names_of_the_first_author,
+      "journal_title" => freecite_response.journal_title,
+      "volume" => freecite_response.volume,
+      "pages" => freecite_response.pages,
+      "publisher" => freecite_response.publisher,
+      "year" => freecite_response.year,
+      "title" => freecite_response.title
+    }
+  end
+
+  def already_refined?(query)
+    query.include?(':') && query.include?('"')
+  end
+
+  def parse_refined_query_to_jsonable_structure(query)
+    {
+      "authors" => parse_field_from_refined_query("authors", query),
+      "journal_title" => parse_field_from_refined_query("journal_title", query),
+      "volume" => parse_field_from_refined_query("volume", query),
+      "pages" => parse_field_from_refined_query("pages", query),
+      "publisher" => parse_field_from_refined_query("publisher", query),
+      "year" => parse_field_from_refined_query("year", query),
+      "title" => parse_field_from_refined_query("title", query)
+    }
+  end
+
+  def parse_field_from_refined_query(fieldname, query)
+    Regexp.new('(?:^|\s)' + fieldname + ':"([^"]+)"')
+      .match(query) { |match| match[1] } || ""
+  end
+end

--- a/app/helpers/freecite_helper.rb
+++ b/app/helpers/freecite_helper.rb
@@ -1,0 +1,125 @@
+require 'uri'
+require 'nokogiri'
+
+# TODO TLNI: Move these classes (They are not Helpers ... But where to?)
+module FreeciteHelper
+  class FreeciteResponse
+    def initialize(values = {})
+      @values = values
+    end
+
+    def authors
+      @values[:authors] || []
+    end
+
+    def unabbreviated_names_of_the_first_author
+      (authors.first || "").split(/\s+/).select { |word| word.length > 1 }.join(" ") || ""
+    end
+
+    def journal_title
+      @values[:journal_title] || ""
+    end
+
+    def volume
+      @values[:volume] || ""
+    end
+
+    def pages
+      @values[:pages] || ""
+    end
+
+    def publisher
+      @values[:publisher] || ""
+    end
+
+    def title
+      @values[:title] || ""
+    end
+
+    def year
+      @values[:year] || ""
+    end
+  end
+
+  class FreeciteRequest
+    def initialize(query)
+      @query = query
+    end
+
+    def query
+      @query
+    end
+
+    def call
+      begin
+        parse_http_response(perform_post_request)
+      rescue Exception => e
+        FreeciteResponse.new
+      end
+    end
+
+    def parse_http_response(http_response)
+      doc = Nokogiri::XML(http_response)
+      doc.remove_namespaces!
+
+      FreeciteResponse.new({
+        :authors => xpath_list(doc, "/citations/citation[1]/authors/author"),
+        :journal_title => xpath(doc, "/citations/citation[1]/journal"),
+        :volume => xpath(doc, "/citations/citation[1]/volume"),
+        :pages => xpath(doc, "/citations/citation[1]/pages"),
+        :publisher => xpath(doc, "/citations/citation[1]/publisher"),
+        :year => xpath(doc, "/citations/citation[1]/year"),
+        :title => xpath(doc, "/citations/citation[1]/title")
+      })
+    end
+
+    def xpath(doc, xpath_expr, default_value = "")
+      element = doc.xpath(xpath_expr).first
+      if element.nil?
+        default_value
+      else
+        element.text
+      end
+    end
+
+    def xpath_list(doc, xpath_expr, default_value = "")
+      elements = (doc.xpath(xpath_expr) || [])
+      elements.collect do |element|
+        if element.nil?
+          default_value
+        else
+          element.text
+        end
+      end
+    end
+
+    def perform_post_request
+      uri = URI(freecite_base_url)
+
+      http = Net::HTTP.new(uri.host, uri.port)
+      if uri.scheme == "https"
+        http.use_ssl = true
+      end
+
+      http_response = http.start do |http|
+        request = Net::HTTP::Post.new(uri)
+
+        request["Accept"] = "application/xml, text/xml, */*; q=0.01"
+
+        request.set_form_data('citation' => query)
+
+        http.request(request)
+      end
+
+      if http_response.code != "200"
+        raise Exception.new("Freecite - HTTP request failed (response code != 200)")
+      end
+
+      http_response.body
+    end
+
+    def freecite_base_url
+      "http://freecite.library.brown.edu/citations/create"
+    end
+  end
+end

--- a/app/helpers/refine_search_helper.rb
+++ b/app/helpers/refine_search_helper.rb
@@ -1,0 +1,2 @@
+module RefineSearchHelper
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -45,6 +45,7 @@ class Ability
       if user.roles.include? Role.find_by_code('ADM')
         can :update, User
         can :select, :supplier
+        can :view, :refine_search_query
       end
 
       if user.roles.include? Role.find_by_code('SUP')

--- a/app/views/catalog/_refine_search_query.html.erb
+++ b/app/views/catalog/_refine_search_query.html.erb
@@ -1,0 +1,11 @@
+<div style="display: none;" id="show_refine_search_query"><a href="#">Refine search query</a></div>
+<div class="well" style="display: none;" id="refine_search_query" data-query="<%= @query %>">
+    <div id="refined_authors">Authors: <input style="width: 460px;" id="refined_authors_input" type="text" value=""/></div>
+    <div id="refined_title">Title: <input style="width: 460px;" id="refined_title_input" type="text" value=""/></div>
+    <div id="refined_journal">Journal: <input style="width: 460px;" id="refined_journal_input" type="text" value=""/></div>
+    <div id="refined_volume">Volume: <input style="width: 460px;" id="refined_volume_input" type="text" value=""/></div>
+    <div id="refined_pages">Pages: <input style="width: 460px;" id="refined_pages_input" type="text" value=""/></div>
+    <div id="refined_publisher">Publisher: <input style="width: 460px;" id="refined_publisher_input" type="text" value=""/></div>
+    <div id="refined_year">Year: <input style="width: 460px;" id="refined_year_input" type="text" value=""/></div>
+    <div><a href="#" id="do_refined_search">Do refined search</a></div>
+</div>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -12,7 +12,7 @@
 
       <% @page_title = t('blacklight.search.title', :application_name => application_name) %>
 
-
+      <%= render :partial => 'refine_search_query' %>
 
       <%= render 'sort_and_per_page' %>
 

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -12,7 +12,7 @@
 
       <% @page_title = t('blacklight.search.title', :application_name => application_name) %>
 
-      <%= render :partial => 'refine_search_query' %>
+      <%= render :partial => 'refine_search_query' if can? :view, :refine_search_query %>
 
       <%= render 'sort_and_per_page' %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,8 @@ Toshokan::Application.routes.draw do
     get  '/orders/:uuid/resend',                    :to => 'orders#resend',                         :as => 'order_resend_library_support'
     post '/test_payment',                           :to => 'payment#credit_card',                   :as => 'payment'
 
+    # Refine Search
+    get  '/refine_search/parse_search_query',              :to => 'refine_search#parse_search_query',             :as => 'parse_search_query'
 
     # Assistance (Can't Find) forms
     resources :assistance_requests,                 :only => [:index, :new, :create, :show]

--- a/spec/controllers/refine_search_controller_spec.rb
+++ b/spec/controllers/refine_search_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe RefineSearchController, :type => :controller do
+  describe "#parse_search_query" do
+    it "returns JSON" do
+      stub_request(:post, "http://freecite.library.brown.edu/citations/create").
+        to_return(:status => 200, :body => "", :headers => {})
+
+      get(:parse_search_query, {"q" => "query query query"})
+
+      expect(response.header["Content-Type"]).to include("application/json")
+      parsed_response = JSON.parse(response.body)
+    end
+
+    it "reponds with HTTP status = 422 and a body with an error message when no query is passed" do
+      stub_request(:post, "http://freecite.library.brown.edu/citations/create").
+        to_return(:status => 200, :body => "", :headers => {})
+
+      get(:parse_search_query, { })
+
+      expect(response.status).to eq(422)
+      expect(response.body).to match(/must not be empty/)
+    end
+
+    it "parses an already refined query" do
+      stub_request(:post, "http://freecite.library.brown.edu/citations/create").
+        to_return(:status => 200, :body => "", :headers => {})
+
+      get(:parse_search_query, { "q" => 'journal_title:"Test Journal" title:"Test Title"'})
+
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response["journal_title"]).to eq("Test Journal")
+      expect(parsed_response["title"]).to eq("Test Title")
+    end
+  end
+end

--- a/spec/helpers/freecite_helper_spec.rb
+++ b/spec/helpers/freecite_helper_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 describe "FreeciteHelper::FreeciteRequest" do
   describe "#call" do
     it "returns a response with journal title, volume and pages" do
-			stub_request(:post, "http://freecite.library.brown.edu/citations/create").
-				to_return(
+      stub_request(:post, "http://freecite.library.brown.edu/citations/create").
+        to_return(
 :status => 200,
 :body => "<citations>
 <citation valid='false'><authors><author>A K Huber</author><author>M Falk</author><author>M Rohnke</author><author>B Luerssen</author><author>L Gregoratti</author><author>M Amati</author><author>J Janek</author></authors><journal>Physical Chemistry Chemical Physics 2012</journal><volume>14</volume><pages>751</pages><raw_string>Huber, A. K.; Falk, M.; Rohnke, M.; Luerssen, B.; Gregoratti, L.; Amati, M.; Janek, J. Physical Chemistry Chemical Physics 2012, 14, 751</raw_string></citation>
@@ -19,8 +19,8 @@ describe "FreeciteHelper::FreeciteRequest" do
     end
 
     it "returns a response with the unabbreviated names of the first author" do
-			stub_request(:post, "http://freecite.library.brown.edu/citations/create").
-				to_return(
+      stub_request(:post, "http://freecite.library.brown.edu/citations/create").
+        to_return(
 :status => 200,
 :body => "<citations>
 <citation valid='false'><authors><author>A K Huber</author><author>M Falk</author><author>M Rohnke</author><author>B Luerssen</author><author>L Gregoratti</author><author>M Amati</author><author>J Janek</author></authors><journal>Physical Chemistry Chemical Physics 2012</journal><volume>14</volume><pages>751</pages><raw_string>Huber, A. K.; Falk, M.; Rohnke, M.; Luerssen, B.; Gregoratti, L.; Amati, M.; Janek, J. Physical Chemistry Chemical Physics 2012, 14, 751</raw_string></citation>

--- a/spec/helpers/freecite_helper_spec.rb
+++ b/spec/helpers/freecite_helper_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe "FreeciteHelper::FreeciteRequest" do
+  describe "#call" do
+    it "returns a response with journal title, volume and pages" do
+			stub_request(:post, "http://freecite.library.brown.edu/citations/create").
+				to_return(
+:status => 200,
+:body => "<citations>
+<citation valid='false'><authors><author>A K Huber</author><author>M Falk</author><author>M Rohnke</author><author>B Luerssen</author><author>L Gregoratti</author><author>M Amati</author><author>J Janek</author></authors><journal>Physical Chemistry Chemical Physics 2012</journal><volume>14</volume><pages>751</pages><raw_string>Huber, A. K.; Falk, M.; Rohnke, M.; Luerssen, B.; Gregoratti, L.; Amati, M.; Janek, J. Physical Chemistry Chemical Physics 2012, 14, 751</raw_string></citation>
+<ctx:context-objects xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='info:ofi/fmt:xml:xsd:ctx http://www.openurl.info/registry/docs/info:ofi/fmt:xml:xsd:ctx' xmlns:ctx='info:ofi/fmt:xml:xsd:ctx'><ctx:context-object timestamp='2016-06-02T04:54:15-04:00' encoding='info:ofi/enc:UTF-8' version='Z39.88-2004' identifier=''><ctx:referent><ctx:metadata-by-val><ctx:format>info:ofi/fmt:xml:xsd:journal</ctx:format><ctx:metadata><journal xmlns:rft='info:ofi/fmt:xml:xsd:journal' xsi:schemaLocation='info:ofi/fmt:xml:xsd:journal http://www.openurl.info/registry/docs/info:ofi/fmt:xml:xsd:journal'><rft:date></rft:date><rft:stitle>Physical Chemistry Chemical Physics 2012</rft:stitle><rft:genre>article</rft:genre><rft:pages>751</rft:pages><rft:volume>14</rft:volume><rft:au>A K Huber</rft:au><rft:au>M Falk</rft:au><rft:au>M Rohnke</rft:au><rft:au>B Luerssen</rft:au><rft:au>L Gregoratti</rft:au><rft:au>M Amati</rft:au><rft:au>J Janek</rft:au></journal></ctx:metadata></ctx:metadata-by-val></ctx:referent></ctx:context-object></ctx:context-objects></citations>",
+ :headers => {})
+
+      response = FreeciteHelper::FreeciteRequest.new("Huber, A. K.; Falk, M.; Rohnke, M.; Luerssen, B.; Gregoratti, L.; Amati, M.; Janek, J. Physical Chemistry Chemical Physics 2012, 14, 751").call
+
+      expect(response.journal_title).to eq("Physical Chemistry Chemical Physics 2012")
+      expect(response.volume).to eq("14")
+      expect(response.pages).to eq("751")
+    end
+
+    it "returns a response with the unabbreviated names of the first author" do
+			stub_request(:post, "http://freecite.library.brown.edu/citations/create").
+				to_return(
+:status => 200,
+:body => "<citations>
+<citation valid='false'><authors><author>A K Huber</author><author>M Falk</author><author>M Rohnke</author><author>B Luerssen</author><author>L Gregoratti</author><author>M Amati</author><author>J Janek</author></authors><journal>Physical Chemistry Chemical Physics 2012</journal><volume>14</volume><pages>751</pages><raw_string>Huber, A. K.; Falk, M.; Rohnke, M.; Luerssen, B.; Gregoratti, L.; Amati, M.; Janek, J. Physical Chemistry Chemical Physics 2012, 14, 751</raw_string></citation>
+<ctx:context-objects xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='info:ofi/fmt:xml:xsd:ctx http://www.openurl.info/registry/docs/info:ofi/fmt:xml:xsd:ctx' xmlns:ctx='info:ofi/fmt:xml:xsd:ctx'><ctx:context-object timestamp='2016-06-02T04:54:15-04:00' encoding='info:ofi/enc:UTF-8' version='Z39.88-2004' identifier=''><ctx:referent><ctx:metadata-by-val><ctx:format>info:ofi/fmt:xml:xsd:journal</ctx:format><ctx:metadata><journal xmlns:rft='info:ofi/fmt:xml:xsd:journal' xsi:schemaLocation='info:ofi/fmt:xml:xsd:journal http://www.openurl.info/registry/docs/info:ofi/fmt:xml:xsd:journal'><rft:date></rft:date><rft:stitle>Physical Chemistry Chemical Physics 2012</rft:stitle><rft:genre>article</rft:genre><rft:pages>751</rft:pages><rft:volume>14</rft:volume><rft:au>A K Huber</rft:au><rft:au>M Falk</rft:au><rft:au>M Rohnke</rft:au><rft:au>B Luerssen</rft:au><rft:au>L Gregoratti</rft:au><rft:au>M Amati</rft:au><rft:au>J Janek</rft:au></journal></ctx:metadata></ctx:metadata-by-val></ctx:referent></ctx:context-object></ctx:context-objects></citations>",
+ :headers => {})
+
+      response = FreeciteHelper::FreeciteRequest.new("Huber, A. K.; Falk, M.; Rohnke, M.; Luerssen, B.; Gregoratti, L.; Amati, M.; Janek, J. Physical Chemistry Chemical Physics 2012, 14, 751").call
+
+      expect(response.unabbreviated_names_of_the_first_author).to eq("Huber")
+    end
+  end
+end

--- a/spec/helpers/refine_search_helper_spec.rb
+++ b/spec/helpers/refine_search_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the RefineSearchHelper. For example:
+#
+# describe RefineSearchHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe RefineSearchHelper, :type => :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
A prototype of some functionality that hopefully will help users find the material that they are looking for.

Freecite (http://freecite.library.brown.edu/) is automatically queried when a user searches for something. Freecite tries to parse the user input as a reference (citation). The response from Freecite is presented to the user if they click the "Refine search" link. The user is able to edit the Freecite suggestion before he/she performs a refined search, i.e. a search which includes keywords or field names (e.g. "author:Nielsen").

When a user puts keywords or field names in their query (e.g. "author:Nielsen") Freecite is not queried. Instead keywords are parsed into the individual editable fields which appear when they user clicks the "Refine search" link.

There's numerous issues with the prototype as it is. It could use a review and some (user) testing.
