### PR TITLE
Refine search: Use local/dockerised FreeCite

### DIFF
--- a/app/assets/javascripts/refine_search.js
+++ b/app/assets/javascripts/refine_search.js
@@ -87,7 +87,7 @@
 
         var params = [];
         if (refinedAuthorsInput.val())
-          params.push('authors:"' + refinedAuthorsInput.val() + '"');
+          params.push('author:"' + refinedAuthorsInput.val() + '"');
         if (refinedTitleInput.val())
           params.push('title:"' + refinedTitleInput.val() + '"');
         if (refinedJournalInput.val())
@@ -99,7 +99,7 @@
         if (refinedYearInput.val())
           params.push('year:"' + refinedYearInput.val() + '"');
         if (refinedPagesInput.val())
-          params.push('pages:"' + refinedPagesInput.val() + '"');
+          params.push('page:"' + refinedPagesInput.val() + '"');
 
         var result = baseUrl + encodeURI(params.join(" "));
 

--- a/app/controllers/refine_search_controller.rb
+++ b/app/controllers/refine_search_controller.rb
@@ -1,7 +1,14 @@
 require 'uri'
 
 class RefineSearchController < ApplicationController
+  include RefineSearchHelper
+
   def parse_search_query
+    if not refine_search_configured?
+      render json: {}
+      return
+    end
+
     query = URI.decode(params[:q] || "")
 
     if query.nil? || query.empty?
@@ -14,7 +21,7 @@ class RefineSearchController < ApplicationController
       return
     end
 
-    freecite_response = FreeciteHelper::FreeciteRequest.new(query).call
+    freecite_response = FreeciteHelper::FreeciteRequest.new(Rails.configuration.freecite[:url], query).call
     render json: map_freecite_response_to_jsonable_toshokan_response(freecite_response)
   end
 
@@ -38,10 +45,10 @@ class RefineSearchController < ApplicationController
 
   def parse_refined_query_to_jsonable_structure(query)
     {
-      "authors" => parse_field_from_refined_query("authors", query),
+      "authors" => parse_field_from_refined_query("author", query),
       "journal_title" => parse_field_from_refined_query("journal_title", query),
       "volume" => parse_field_from_refined_query("volume", query),
-      "pages" => parse_field_from_refined_query("pages", query),
+      "pages" => parse_field_from_refined_query("page", query),
       "publisher" => parse_field_from_refined_query("publisher", query),
       "year" => parse_field_from_refined_query("year", query),
       "title" => parse_field_from_refined_query("title", query)

--- a/app/helpers/freecite_helper.rb
+++ b/app/helpers/freecite_helper.rb
@@ -1,5 +1,4 @@
 require 'uri'
-require 'nokogiri'
 
 # TODO TLNI: Move these classes (They are not Helpers ... But where to?)
 module FreeciteHelper
@@ -42,84 +41,44 @@ module FreeciteHelper
   end
 
   class FreeciteRequest
-    def initialize(query)
+    def initialize(freecite_base_url, query)
+      @freecite_base_url = freecite_base_url
       @query = query
     end
-
-    def query
-      @query
-    end
+    attr_reader :freecite_base_url, :query
 
     def call
       begin
-        parse_http_response(perform_post_request)
+        parse_http_response(perform_get_request)
       rescue Exception => e
         FreeciteResponse.new
       end
     end
 
     def parse_http_response(http_response)
-      doc = Nokogiri::XML(http_response)
-      doc.remove_namespaces!
-
+      json = JSON.parse(http_response)
       FreeciteResponse.new({
-        :authors => xpath_list(doc, "/citations/citation[1]/authors/author"),
-        :journal_title => xpath(doc, "/citations/citation[1]/journal"),
-        :volume => xpath(doc, "/citations/citation[1]/volume"),
-        :pages => xpath(doc, "/citations/citation[1]/pages"),
-        :publisher => xpath(doc, "/citations/citation[1]/publisher"),
-        :year => xpath(doc, "/citations/citation[1]/year"),
-        :title => xpath(doc, "/citations/citation[1]/title")
+        :authors => json["authors"],
+        :journal_title => json["journal"],
+        :volume => json["volume"],
+        :pages => json["pages"],
+        :publisher => json["publisher"],
+        :year => json["year"],
+        :title => json["title"]
       })
     end
 
-    def xpath(doc, xpath_expr, default_value = "")
-      element = doc.xpath(xpath_expr).first
-      if element.nil?
-        default_value
-      else
-        element.text
-      end
-    end
-
-    def xpath_list(doc, xpath_expr, default_value = "")
-      elements = (doc.xpath(xpath_expr) || [])
-      elements.collect do |element|
-        if element.nil?
-          default_value
-        else
-          element.text
-        end
-      end
-    end
-
-    def perform_post_request
+    def perform_get_request
       uri = URI(freecite_base_url)
+      uri.query = URI.encode_www_form({ "q" => query })
 
-      http = Net::HTTP.new(uri.host, uri.port)
-      if uri.scheme == "https"
-        http.use_ssl = true
-      end
+      http_response = Net::HTTP.get_response(uri)
 
-      http_response = http.start do |http|
-        request = Net::HTTP::Post.new(uri)
-
-        request["Accept"] = "application/xml, text/xml, */*; q=0.01"
-
-        request.set_form_data('citation' => query)
-
-        http.request(request)
-      end
-
-      if http_response.code != "200"
-        raise Exception.new("Freecite - HTTP request failed (response code != 200)")
+      if not http_response.is_a?(Net::HTTPSuccess)
+        raise Exception.new("Freecite - HTTP request failed")
       end
 
       http_response.body
-    end
-
-    def freecite_base_url
-      "http://freecite.library.brown.edu/citations/create"
     end
   end
 end

--- a/app/helpers/refine_search_helper.rb
+++ b/app/helpers/refine_search_helper.rb
@@ -1,2 +1,5 @@
 module RefineSearchHelper
+  def refine_search_configured?
+    ((Rails.configuration.respond_to?(:freecite)) && (not Rails.configuration.freecite[:url].nil?))
+  end
 end

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -12,7 +12,9 @@
 
       <% @page_title = t('blacklight.search.title', :application_name => application_name) %>
 
-      <%= render :partial => 'refine_search_query' if can? :view, :refine_search_query %>
+      <% if refine_search_configured? && can?(:view, :refine_search_query)%>
+        <%= render :partial => 'refine_search_query' %>
+      <% end %>
 
       <%= render 'sort_and_per_page' %>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -104,6 +104,10 @@ module Toshokan
         :url => 'http://localhost:3003'
     }
 
+    config.freecite = {
+        :url => 'http://freecite:3000/citation/search'
+    }
+
     config.action_mailer.smtp_settings = {
     }
 

--- a/spec/helpers/freecite_helper_spec.rb
+++ b/spec/helpers/freecite_helper_spec.rb
@@ -3,31 +3,25 @@ require 'rails_helper'
 describe "FreeciteHelper::FreeciteRequest" do
   describe "#call" do
     it "returns a response with journal title, volume and pages" do
-      stub_request(:post, "http://freecite.library.brown.edu/citations/create").
-        to_return(
-:status => 200,
-:body => "<citations>
-<citation valid='false'><authors><author>A K Huber</author><author>M Falk</author><author>M Rohnke</author><author>B Luerssen</author><author>L Gregoratti</author><author>M Amati</author><author>J Janek</author></authors><journal>Physical Chemistry Chemical Physics 2012</journal><volume>14</volume><pages>751</pages><raw_string>Huber, A. K.; Falk, M.; Rohnke, M.; Luerssen, B.; Gregoratti, L.; Amati, M.; Janek, J. Physical Chemistry Chemical Physics 2012, 14, 751</raw_string></citation>
-<ctx:context-objects xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='info:ofi/fmt:xml:xsd:ctx http://www.openurl.info/registry/docs/info:ofi/fmt:xml:xsd:ctx' xmlns:ctx='info:ofi/fmt:xml:xsd:ctx'><ctx:context-object timestamp='2016-06-02T04:54:15-04:00' encoding='info:ofi/enc:UTF-8' version='Z39.88-2004' identifier=''><ctx:referent><ctx:metadata-by-val><ctx:format>info:ofi/fmt:xml:xsd:journal</ctx:format><ctx:metadata><journal xmlns:rft='info:ofi/fmt:xml:xsd:journal' xsi:schemaLocation='info:ofi/fmt:xml:xsd:journal http://www.openurl.info/registry/docs/info:ofi/fmt:xml:xsd:journal'><rft:date></rft:date><rft:stitle>Physical Chemistry Chemical Physics 2012</rft:stitle><rft:genre>article</rft:genre><rft:pages>751</rft:pages><rft:volume>14</rft:volume><rft:au>A K Huber</rft:au><rft:au>M Falk</rft:au><rft:au>M Rohnke</rft:au><rft:au>B Luerssen</rft:au><rft:au>L Gregoratti</rft:au><rft:au>M Amati</rft:au><rft:au>J Janek</rft:au></journal></ctx:metadata></ctx:metadata-by-val></ctx:referent></ctx:context-object></ctx:context-objects></citations>",
- :headers => {})
+      stub_request(:get, "http://freecite:3000/citations/search?q=Huber,%20A.%20K.%3B%20Falk,%20M.%3B%20Rohnke,%20M.%3B%20Luerssen,%20B.%3B%20Gregoratti,%20L.%3B%20Amati,%20M.%3B%20Janek,%20J.%20Physical%20Chemistry%20Chemical%20Physics%202012,%2014,%20751").
+        to_return(:status => 200,
+                  :body => '{"author":"Huber,  A. K.,  Falk,  M.,  Rohnke,  M.,  Luerssen,  B.,  Gregoratti,  L.,  Amati,  M.,  Janek,  J. ","journal":"Physical Chemistry Chemical Physics","date":2012,"volume":"14","pages":"751","authors":["A K Huber","M Falk","M Rohnke","B Luerssen","L Gregoratti","M Amati","J Janek"],"year":2012,"raw_string":"Huber, A. K.; Falk, M.; Rohnke, M.; Luerssen, B.; Gregoratti, L.; Amati, M.; Janek, J. Physical Chemistry Chemical Physics 2012, 14, 751"}',
+                  :headers => {})
 
-      response = FreeciteHelper::FreeciteRequest.new("Huber, A. K.; Falk, M.; Rohnke, M.; Luerssen, B.; Gregoratti, L.; Amati, M.; Janek, J. Physical Chemistry Chemical Physics 2012, 14, 751").call
+      response = FreeciteHelper::FreeciteRequest.new("http://freecite:3000/citations/search", "Huber, A. K.; Falk, M.; Rohnke, M.; Luerssen, B.; Gregoratti, L.; Amati, M.; Janek, J. Physical Chemistry Chemical Physics 2012, 14, 751").call
 
-      expect(response.journal_title).to eq("Physical Chemistry Chemical Physics 2012")
+      expect(response.journal_title).to eq("Physical Chemistry Chemical Physics")
       expect(response.volume).to eq("14")
       expect(response.pages).to eq("751")
     end
 
     it "returns a response with the unabbreviated names of the first author" do
-      stub_request(:post, "http://freecite.library.brown.edu/citations/create").
-        to_return(
-:status => 200,
-:body => "<citations>
-<citation valid='false'><authors><author>A K Huber</author><author>M Falk</author><author>M Rohnke</author><author>B Luerssen</author><author>L Gregoratti</author><author>M Amati</author><author>J Janek</author></authors><journal>Physical Chemistry Chemical Physics 2012</journal><volume>14</volume><pages>751</pages><raw_string>Huber, A. K.; Falk, M.; Rohnke, M.; Luerssen, B.; Gregoratti, L.; Amati, M.; Janek, J. Physical Chemistry Chemical Physics 2012, 14, 751</raw_string></citation>
-<ctx:context-objects xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='info:ofi/fmt:xml:xsd:ctx http://www.openurl.info/registry/docs/info:ofi/fmt:xml:xsd:ctx' xmlns:ctx='info:ofi/fmt:xml:xsd:ctx'><ctx:context-object timestamp='2016-06-02T04:54:15-04:00' encoding='info:ofi/enc:UTF-8' version='Z39.88-2004' identifier=''><ctx:referent><ctx:metadata-by-val><ctx:format>info:ofi/fmt:xml:xsd:journal</ctx:format><ctx:metadata><journal xmlns:rft='info:ofi/fmt:xml:xsd:journal' xsi:schemaLocation='info:ofi/fmt:xml:xsd:journal http://www.openurl.info/registry/docs/info:ofi/fmt:xml:xsd:journal'><rft:date></rft:date><rft:stitle>Physical Chemistry Chemical Physics 2012</rft:stitle><rft:genre>article</rft:genre><rft:pages>751</rft:pages><rft:volume>14</rft:volume><rft:au>A K Huber</rft:au><rft:au>M Falk</rft:au><rft:au>M Rohnke</rft:au><rft:au>B Luerssen</rft:au><rft:au>L Gregoratti</rft:au><rft:au>M Amati</rft:au><rft:au>J Janek</rft:au></journal></ctx:metadata></ctx:metadata-by-val></ctx:referent></ctx:context-object></ctx:context-objects></citations>",
- :headers => {})
+      stub_request(:get, "http://freecite:3000/citations/search?q=Huber,%20A.%20K.%3B%20Falk,%20M.%3B%20Rohnke,%20M.%3B%20Luerssen,%20B.%3B%20Gregoratti,%20L.%3B%20Amati,%20M.%3B%20Janek,%20J.%20Physical%20Chemistry%20Chemical%20Physics%202012,%2014,%20751").
+        to_return(:status => 200,
+                  :body => '{"author":"Huber,  A. K.,  Falk,  M.,  Rohnke,  M.,  Luerssen,  B.,  Gregoratti,  L.,  Amati,  M.,  Janek,  J. ","journal":"Physical Chemistry Chemical Physics","date":2012,"volume":"14","pages":"751","authors":["A K Huber","M Falk","M Rohnke","B Luerssen","L Gregoratti","M Amati","J Janek"],"year":2012,"raw_string":"Huber, A. K.; Falk, M.; Rohnke, M.; Luerssen, B.; Gregoratti, L.; Amati, M.; Janek, J. Physical Chemistry Chemical Physics 2012, 14, 751"}',
+                  :headers => {})
 
-      response = FreeciteHelper::FreeciteRequest.new("Huber, A. K.; Falk, M.; Rohnke, M.; Luerssen, B.; Gregoratti, L.; Amati, M.; Janek, J. Physical Chemistry Chemical Physics 2012, 14, 751").call
+      response = FreeciteHelper::FreeciteRequest.new("http://freecite:3000/citations/search", "Huber, A. K.; Falk, M.; Rohnke, M.; Luerssen, B.; Gregoratti, L.; Amati, M.; Janek, J. Physical Chemistry Chemical Physics 2012, 14, 751").call
 
       expect(response.unabbreviated_names_of_the_first_author).to eq("Huber")
     end


### PR DESCRIPTION
This PR removes a dependency on a remotely hosted FreeCite service.

Before the 'refine search'-functionality is available in production a FreeCite service has to be deployed (https://github.com/dtulibrary/freecite-docker) and the URL of the deployed FreeCite service has to be configured (https://github.com/dtulibrary/toshokan/blob/a7498612ae59c13c2bd04b087177a07c7b079ba3/config/application.rb#L107).

The 'refine search'-functionality is disabled if no FreeCite URL is configured. The functionality is only visible to Administrator users.
