### PR TITLE
Fix search input css issue on Chrome

### DIFF
--- a/app/assets/stylesheets/_search.scss
+++ b/app/assets/stylesheets/_search.scss
@@ -10,7 +10,7 @@
   .text-field-with-icons {
     background-color: #fff;
     border: 1px solid #d4d4d4;
-    padding: 2px 5px;
+    padding: 2px 4px;
     height: 34px;
     width: 446px;
     float: left;


### PR DESCRIPTION
The search field input box jumps out of the form on certain sizes in Chrome:

![2016-08-17_1036x424](https://cloud.githubusercontent.com/assets/1689020/17730754/985c2d7c-646a-11e6-9b28-24b2f5af526f.png)
